### PR TITLE
fix: wallet adapter network for mainnet added

### DIFF
--- a/packages/core/base/types.ts
+++ b/packages/core/base/types.ts
@@ -2,6 +2,7 @@ export enum WalletAdapterNetwork {
     Testnet = 'testnet3',
     TestnetBeta = 'testnetbeta',
     MainnetBeta = 'mainnetbeta',
+    Mainnet= 'mainnet'
 };
 
 export type SupportedTransactionVersions = ReadonlySet<any> | null;


### PR DESCRIPTION
Problem:
The `WalletAdapterNetwork` enum did not include "mainnet", while the Leo wallet expected this exact value. Consequently, the frontend transaction failed to trigger the Leo wallet, it logged incorrect parameters in console as it expected "mainnet" while we had set `WalletAdapterNetwork.MainnetBeta`.

Solution:
Added Mainnet = "mainnet" to the `WalletAdapterNetwork` enum to ensure compatibility with the Leo wallet.